### PR TITLE
[KT2-7] Adiciona entity ParkSpot para movimentações da vaga

### DIFF
--- a/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/entity/ParkingSpot.kt
+++ b/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/entity/ParkingSpot.kt
@@ -1,0 +1,28 @@
+package io.devpass.parky.entity
+
+import org.hibernate.annotations.CreationTimestamp
+import java.time.LocalDateTime
+import javax.persistence.Entity
+import javax.persistence.Id
+import kotlin.math.absoluteValue
+import kotlin.random.Random
+
+@Entity
+data class ParkingSpot(
+        @Id
+        var id: Int = Random.nextInt().absoluteValue,
+        var parking_spot_id: Int,
+        var floor: Int,
+        var spot: Int,
+        var inUseBy: Int,
+        @CreationTimestamp
+        var createdAt: LocalDateTime = LocalDateTime.now()
+)
+
+
+
+
+
+
+
+

--- a/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/entity/ParkingSpotMovement.kt
+++ b/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/entity/ParkingSpotMovement.kt
@@ -13,11 +13,3 @@ data class ParkingSpotMovement(
         @CreationTimestamp
         var createdAt: LocalDateTime
 )
-
-
-
-
-
-
-
-

--- a/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/entity/ParkingSpotMovement.kt
+++ b/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/entity/ParkingSpotMovement.kt
@@ -8,7 +8,7 @@ import kotlin.math.absoluteValue
 import kotlin.random.Random
 
 @Entity
-data class ParkingSpot(
+data class ParkingSpotMovement(
         @Id
         var id: Int = Random.nextInt().absoluteValue,
         var parking_spot_id: Int,

--- a/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/entity/ParkingSpotMovement.kt
+++ b/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/entity/ParkingSpotMovement.kt
@@ -4,19 +4,14 @@ import org.hibernate.annotations.CreationTimestamp
 import java.time.LocalDateTime
 import javax.persistence.Entity
 import javax.persistence.Id
-import kotlin.math.absoluteValue
-import kotlin.random.Random
 
 @Entity
 data class ParkingSpotMovement(
         @Id
-        var id: Int = Random.nextInt().absoluteValue,
         var parking_spot_id: Int,
-        var floor: Int,
-        var spot: Int,
-        var inUseBy: Int,
+        var event: Int,
         @CreationTimestamp
-        var createdAt: LocalDateTime = LocalDateTime.now()
+        var createdAt: LocalDateTime
 )
 
 

--- a/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/entity/ParkingSpotMovement.kt
+++ b/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/entity/ParkingSpotMovement.kt
@@ -8,7 +8,7 @@ import javax.persistence.Id
 @Entity
 data class ParkingSpotMovement(
         @Id
-        var parking_spot_id: Int,
+        var parkingSpotId: Int,
         var event: Int,
         @CreationTimestamp
         var createdAt: LocalDateTime


### PR DESCRIPTION
## Descrição 

Cria @Entity que representa a tabela de movimentações de vaga.

Critérios de aceitação

- [ ]  Arquivo está no package adequado
- [ ]  Anotações utilizadas corretamente
- [ ]  O service pede um repository como parâmetro de construção

#### Observação: @Incognitowski Fiquei em dúvida se os campos corretos são os da tabela spot ou spot_event, então fiz colocando os campos de ambos, pensando que precisamos do id random do veiculo (id) e o da vaga (parking_spot_id) e informações sobre a vaga para saber a movimentação dela. Só não coloquei event. Está correto?