### PR TITLE
[hotfix] Corrige import da entity ParkingSpotMovement

### DIFF
--- a/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/controller/ParkingSpotMovementController.kt
+++ b/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/controller/ParkingSpotMovementController.kt
@@ -1,7 +1,7 @@
 package io.devpass.parky.controller
 
 import io.devpass.parky.service.ParkingSpotMovementService
-import io.devpass.parky.service.entity.ParkingSpotMovement
+import io.devpass.parky.entity.ParkingSpotMovement
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable

--- a/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/repository/ParkingSpotMovementRepository.kt
+++ b/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/repository/ParkingSpotMovementRepository.kt
@@ -1,6 +1,6 @@
 package io.devpass.parky.repository
 
-import io.devpass.parky.service.entity.ParkingSpotMovement
+import io.devpass.parky.entity.ParkingSpotMovement
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.CrudRepository
 import org.springframework.stereotype.Repository

--- a/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/service/ParkingSpotMovementService.kt
+++ b/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/service/ParkingSpotMovementService.kt
@@ -1,7 +1,7 @@
 package io.devpass.parky.service
 
 import io.devpass.parky.repository.ParkingSpotMovementRepository
-import io.devpass.parky.service.entity.ParkingSpotMovement
+import io.devpass.parky.entity.ParkingSpotMovement
 import org.springframework.stereotype.Service
 
 @Service


### PR DESCRIPTION
Deletamos o `service.` que estava no import da entity e impedia o build da aplicação.