### PR TITLE
[KT2-27] Cria recurso de busca aleatória em andar específico

### DIFF
--- a/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/controller/ParkingSpotController.kt
+++ b/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/controller/ParkingSpotController.kt
@@ -34,4 +34,11 @@ class ParkingSpotController(
         } else ResponseEntity.notFound().build()
     }
 
+    @GetMapping("/random-available/floor/{floor}")
+    fun getRandomParkingSpotByFloor(
+        @PathVariable floor: Int
+    ): ParkingSpot {
+        return parkingSpotService.findEmptyParkingSpotByFloor(floor)
+    }
+
 }

--- a/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/repository/ParkingSpotRepository.kt
+++ b/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/repository/ParkingSpotRepository.kt
@@ -10,4 +10,7 @@ interface ParkingSpotRepository : CrudRepository<ParkingSpot, Int>{
 
     @Query("SELECT ps from ParkingSpot ps where ps.inUseBy is null")
     fun getRandomEmptyParkingSpot(): List<ParkingSpot>
+
+    @Query("SELECT ps from ParkingSpot ps where ps.floor = ?1 and ps.inUseBy is null")
+    fun getParkingSpotByFloor(floor: Int): List<ParkingSpot>
 }

--- a/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/service/ParkingSpotService.kt
+++ b/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/service/ParkingSpotService.kt
@@ -22,4 +22,8 @@ class ParkingSpotService(
     fun findEmptyParkingSpotAtRandom(): ParkingSpot{
         return parkingSpotRepository.getRandomEmptyParkingSpot().random()
     }
+
+    fun findEmptyParkingSpotByFloor(floor: Int): ParkingSpot {
+        return parkingSpotRepository.getParkingSpotByFloor(floor).random()
+    }
 }


### PR DESCRIPTION
### Possibilitar a consulta via *endpoint*, de uma vaga disponível escolhida de maneira aleatória,  em um andar específico.

A alteração deve ser feita em todas as camadas da aplicação: *repository*, *service*, e *controller*.

Lembrando que a indicação de disponibilidade da vaga é o campo “*in_use_by*” da *entity* de vaga, e o campo que representa o andar é o campo “*floor*”, também da *entity* de vaga.

## Critérios de aceitação:

- [ ]  O filtro de vaga em uso é feito no nível do *repository*.
- [ ]  A seleção de vaga é feita aleatoriamente dentro do *service* após consulta.