### PR TITLE
[KT2-30] Criar endpoint para registrar pedido de notificação de vaga disponível

### DIFF
--- a/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/controller/AvailableParkingSpotNotificationController.kt
+++ b/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/controller/AvailableParkingSpotNotificationController.kt
@@ -1,10 +1,7 @@
 package io.devpass.parky.controller
 
-import io.devpass.parky.entity.ParkingSpot
-import io.devpass.parky.repository.AvailableParkingSpotNotificationRepository
 import io.devpass.parky.requests.AvailableParkingSpotNotificationRequest
 import io.devpass.parky.service.AvailableParkingSpotNotificationService
-import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -14,10 +11,7 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/available-parking-spot")
 class AvailableParkingSpotNotificationController(
     private val availableParkingSpotNotificationService: AvailableParkingSpotNotificationService,
-){
-    //criar endpoint para o usuario criar notificaçao
-    //post
-
+) {
     @PostMapping
     fun createNotification(
         @RequestBody availableParkingSpotNotificationRequest: AvailableParkingSpotNotificationRequest

--- a/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/controller/AvailableParkingSpotNotificationController.kt
+++ b/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/controller/AvailableParkingSpotNotificationController.kt
@@ -1,6 +1,12 @@
 package io.devpass.parky.controller
 
+import io.devpass.parky.entity.ParkingSpot
+import io.devpass.parky.repository.AvailableParkingSpotNotificationRepository
+import io.devpass.parky.requests.AvailableParkingSpotNotificationRequest
 import io.devpass.parky.service.AvailableParkingSpotNotificationService
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -8,4 +14,13 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/available-parking-spot")
 class AvailableParkingSpotNotificationController(
     private val availableParkingSpotNotificationService: AvailableParkingSpotNotificationService,
-)
+){
+    //criar endpoint para o usuario criar notificaçao
+    //post
+
+    @PostMapping
+    fun createNotification(
+        @RequestBody availableParkingSpotNotificationRequest: AvailableParkingSpotNotificationRequest
+    ) =
+        availableParkingSpotNotificationService.createNotification(availableParkingSpotNotificationRequest)
+}

--- a/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/exceptions/NotificationException.kt
+++ b/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/exceptions/NotificationException.kt
@@ -1,0 +1,5 @@
+package io.devpass.parky.exceptions
+
+import io.devpass.parky.framework.OwnedException
+
+class NotificationException(message: String) : OwnedException(message)

--- a/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/repository/AvailableParkingSpotNotificationRepository.kt
+++ b/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/repository/AvailableParkingSpotNotificationRepository.kt
@@ -1,8 +1,13 @@
 package io.devpass.parky.repository
 
 import io.devpass.parky.entity.AvailableParkingSpotNotification
+import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.CrudRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface AvailableParkingSpotNotificationRepository : CrudRepository<AvailableParkingSpotNotification, Int>
+interface AvailableParkingSpotNotificationRepository : CrudRepository<AvailableParkingSpotNotification, Int> {
+
+    @Query("select apsn from AvailableParkingSpotNotification apsn where apsn.parkingSpotId = ?1 and apsn.email = ?2")
+    fun findEmailAndParkingSpotId(parkingSpotId: Int, email: String): List<AvailableParkingSpotNotification>
+}

--- a/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/requests/AvailableParkingSpotNotificationRequest.kt
+++ b/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/requests/AvailableParkingSpotNotificationRequest.kt
@@ -1,0 +1,6 @@
+package io.devpass.parky.requests
+
+data class AvailableParkingSpotNotificationRequest(
+    val parkingSpotId: Int,
+    val email: String,
+)

--- a/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/service/AvailableParkingSpotNotificationService.kt
+++ b/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/service/AvailableParkingSpotNotificationService.kt
@@ -8,13 +8,26 @@ import org.springframework.stereotype.Service
 @Service
 class AvailableParkingSpotNotificationService(
     private val availableParkingSpotNotificationRepository: AvailableParkingSpotNotificationRepository,
-){
-    fun createNotification(availableParkingSpotNotificationRequest: AvailableParkingSpotNotificationRequest){
-        availableParkingSpotNotificationRepository.save(
-            AvailableParkingSpotNotification(
-                parkingSpotId = availableParkingSpotNotificationRequest.parkingSpotId,
-                email = availableParkingSpotNotificationRequest.email,
-            )
+) {
+
+    fun createNotification(availableParkingSpotNotificationRequest: AvailableParkingSpotNotificationRequest) {
+        //checar se há notificacao criada para aquele email && vaga
+
+        val notificationCreated = availableParkingSpotNotificationRepository.findEmailAndParkingSpotId(
+            availableParkingSpotNotificationRequest.parkingSpotId,
+            availableParkingSpotNotificationRequest.email,
         )
+
+        if (notificationCreated.isNotEmpty()) {
+            println("Already exists a notification appointed.")
+        } else {
+            availableParkingSpotNotificationRepository.save(
+                AvailableParkingSpotNotification(
+                    parkingSpotId = availableParkingSpotNotificationRequest.parkingSpotId,
+                    email = availableParkingSpotNotificationRequest.email,
+                )
+            )
+        }
+
     }
 }

--- a/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/service/AvailableParkingSpotNotificationService.kt
+++ b/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/service/AvailableParkingSpotNotificationService.kt
@@ -11,7 +11,6 @@ class AvailableParkingSpotNotificationService(
 ) {
 
     fun createNotification(availableParkingSpotNotificationRequest: AvailableParkingSpotNotificationRequest) {
-        //checar se há notificacao criada para aquele email && vaga
 
         val notificationCreated = availableParkingSpotNotificationRepository.findEmailAndParkingSpotId(
             availableParkingSpotNotificationRequest.parkingSpotId,

--- a/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/service/AvailableParkingSpotNotificationService.kt
+++ b/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/service/AvailableParkingSpotNotificationService.kt
@@ -27,6 +27,5 @@ class AvailableParkingSpotNotificationService(
                 )
             )
         }
-
     }
 }

--- a/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/service/AvailableParkingSpotNotificationService.kt
+++ b/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/service/AvailableParkingSpotNotificationService.kt
@@ -1,9 +1,20 @@
 package io.devpass.parky.service
 
+import io.devpass.parky.entity.AvailableParkingSpotNotification
 import io.devpass.parky.repository.AvailableParkingSpotNotificationRepository
+import io.devpass.parky.requests.AvailableParkingSpotNotificationRequest
 import org.springframework.stereotype.Service
 
 @Service
 class AvailableParkingSpotNotificationService(
     private val availableParkingSpotNotificationRepository: AvailableParkingSpotNotificationRepository,
-)
+){
+    fun createNotification(availableParkingSpotNotificationRequest: AvailableParkingSpotNotificationRequest){
+        availableParkingSpotNotificationRepository.save(
+            AvailableParkingSpotNotification(
+                parkingSpotId = availableParkingSpotNotificationRequest.parkingSpotId,
+                email = availableParkingSpotNotificationRequest.email,
+            )
+        )
+    }
+}

--- a/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/service/AvailableParkingSpotNotificationService.kt
+++ b/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/service/AvailableParkingSpotNotificationService.kt
@@ -1,6 +1,7 @@
 package io.devpass.parky.service
 
 import io.devpass.parky.entity.AvailableParkingSpotNotification
+import io.devpass.parky.exceptions.NotificationException
 import io.devpass.parky.repository.AvailableParkingSpotNotificationRepository
 import io.devpass.parky.requests.AvailableParkingSpotNotificationRequest
 import org.springframework.stereotype.Service
@@ -18,7 +19,7 @@ class AvailableParkingSpotNotificationService(
         )
 
         if (notificationCreated.isNotEmpty()) {
-            println("Already exists a notification appointed.")
+            throw NotificationException("Already exists a notification appointed.")
         } else {
             availableParkingSpotNotificationRepository.save(
                 AvailableParkingSpotNotification(


### PR DESCRIPTION
## Os usuários do App precisam de um *endpoint* para registrar um pedido para serem notificados quando houver o check-out de uma vaga de sua preferência.

Utilize o *controller* criado na tarefa 28 para criar um *endpoint* que vai registrar um pedido de notificação.

## Critérios de aceite

- [ ]  O mesmo e-mail não pode registrar um pedido para a mesma vaga duas vezes.
- [ ]  O *endpoint* insere o pedido adequadamente no banco de dados.
- [ ]  O *endpoint* está com o verbo adequado.