### PR TITLE
[KT2-29] Altera o fluxo de check-out para notificações

### DIFF
--- a/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/repository/AvailableParkingSpotNotificationRepository.kt
+++ b/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/repository/AvailableParkingSpotNotificationRepository.kt
@@ -1,8 +1,12 @@
 package io.devpass.parky.repository
 
 import io.devpass.parky.entity.AvailableParkingSpotNotification
+import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.CrudRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface AvailableParkingSpotNotificationRepository : CrudRepository<AvailableParkingSpotNotification, Int>
+interface AvailableParkingSpotNotificationRepository : CrudRepository<AvailableParkingSpotNotification, Int> {
+    @Query("SELECT apsn from AvailableParkingSpotNotification apsn where apsn.parkingSpotId = ?1")
+    fun findByParkingSpotId(parkingSpotId: Int): List<AvailableParkingSpotNotification>
+}

--- a/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/service/AvailableParkingSpotNotificationService.kt
+++ b/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/service/AvailableParkingSpotNotificationService.kt
@@ -12,7 +12,8 @@ class AvailableParkingSpotNotificationService(
     fun checkOutNotification(parkingSpotId: Int) {
         val availableParkingSpotNotification =
             availableParkingSpotNotificationRepository.findByParkingSpotId(parkingSpotId).ifEmpty {
-                throw OwnedException("Notificação não encontrada para a vaga $parkingSpotId!")
+                println("Nenhuma pessoa precisou ser notificada")
+                return
             }
         availableParkingSpotNotification.forEach {
             println("O email é ${it.email}")

--- a/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/service/AvailableParkingSpotNotificationService.kt
+++ b/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/service/AvailableParkingSpotNotificationService.kt
@@ -1,9 +1,27 @@
 package io.devpass.parky.service
 
+import io.devpass.parky.entity.AvailableParkingSpotNotification
+import io.devpass.parky.framework.OwnedException
 import io.devpass.parky.repository.AvailableParkingSpotNotificationRepository
 import org.springframework.stereotype.Service
 
 @Service
 class AvailableParkingSpotNotificationService(
     private val availableParkingSpotNotificationRepository: AvailableParkingSpotNotificationRepository,
-)
+) {
+    fun checkOutNotification(parkingSpotId: Int) {
+        val availableParkingSpotNotification =
+            availableParkingSpotNotificationRepository.findByParkingSpotId(parkingSpotId).ifEmpty {
+                throw OwnedException("Notificação não encontrada para a vaga $parkingSpotId!")
+            }
+        availableParkingSpotNotification.forEach {
+            println("O email é ${it.email}")
+            println("A vaga ${it.parkingSpotId} está disponível!")
+            deleteNotification(it)
+        }
+    }
+
+    fun deleteNotification(availableParkingSpotNotification: AvailableParkingSpotNotification) {
+        availableParkingSpotNotificationRepository.delete(availableParkingSpotNotification)
+    }
+}

--- a/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/service/CheckInOutService.kt
+++ b/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/service/CheckInOutService.kt
@@ -8,6 +8,7 @@ class CheckInOutService(
     private val parkingSpotMovementService: ParkingSpotMovementService,
     private val vehicleService: VehicleService,
     private val parkingSpotService: ParkingSpotService,
+    private val availableParkingSpotNotificationService: AvailableParkingSpotNotificationService,
 ) {
     fun removeCheckIn(parkingSpotId: Int) {
         val parkingSpot = parkingSpotService.findById(parkingSpotId)
@@ -25,5 +26,6 @@ class CheckInOutService(
 
         parkingSpot.inUseBy = null
         parkingSpotService.update(parkingSpot)
+        availableParkingSpotNotificationService.checkOutNotification(parkingSpotId)
     }
 }


### PR DESCRIPTION
## Você deve alterar o fluxo de check-out para “notificar” todos os usuários que pediram para ser notificados quando uma vaga específica estivesse livre.

Com “notificar”, por hora pode simplesmente realizar um println() para cada registro que está dentro da tabela.

## Critérios de aceitação:

- [x]  Lógica do fluxo de check-out original mantida;
- [x]  Somente os usuários que pediram para ser notificados sobre a vaga específica são notificados;
- [x]  Registros de pedido de notificação são excluídos após a notificação.

Co-authored-by: livioqueiroz <queiroz.livio@gmail.com>