### PR TITLE
[KT2-31] Endpoint administrativo para limpar todas as vagas

### DIFF
--- a/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/controller/AdminController.kt
+++ b/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/controller/AdminController.kt
@@ -7,12 +7,11 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping("/admin/free-all-parking-spots")
-
+@RequestMapping("/admin")
 class AdminController(
     private val checkInOutService: CheckInOutService
 ) {
-    @PostMapping
+    @PostMapping("/free-all-parking-spots")
     fun freeAllParkingSpots(): HttpStatus {
         checkInOutService.cleanAllParkingSpots()
         return HttpStatus.OK

--- a/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/controller/AdminController.kt
+++ b/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/controller/AdminController.kt
@@ -13,7 +13,7 @@ class AdminController(
     private val checkInOutService: CheckInOutService
 ) {
     @PostMapping
-    fun cleanAllParkingSpots(): HttpStatus {
+    fun freeAllParkingSpots(): HttpStatus {
         checkInOutService.cleanAllParkingSpots()
         return HttpStatus.OK
     }

--- a/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/controller/AdminController.kt
+++ b/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/controller/AdminController.kt
@@ -1,0 +1,20 @@
+package io.devpass.parky.controller
+
+import io.devpass.parky.service.CheckInOutService
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/admin/free-all-parking-spots")
+
+class AdminController(
+    private val checkInOutService: CheckInOutService
+) {
+    @PostMapping
+    fun cleanAllParkingSpots(): HttpStatus {
+        checkInOutService.cleanAllParkingSpots()
+        return HttpStatus.OK
+    }
+}

--- a/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/service/CheckInOutService.kt
+++ b/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/service/CheckInOutService.kt
@@ -1,5 +1,6 @@
 package io.devpass.parky.service
 
+import io.devpass.parky.entity.ParkingSpot
 import io.devpass.parky.entity.ParkingSpotMovement
 import io.devpass.parky.entity.Vehicle
 import io.devpass.parky.framework.OwnedException
@@ -58,16 +59,9 @@ class CheckInOutService(
         availableParkingSpotNotificationService.checkOutNotification(parkingSpotId)
     }
 
-    fun checkOutFromAdmin(parkingSpotId: Int) {
-        val parkingSpot = parkingSpotService.findById(parkingSpotId)
-            ?: throw Exception("Vaga não encontrada")
-
-        if (parkingSpot.inUseBy == null) {
-            throw Exception("Vaga livre")
-        }
-
+    fun checkOutFromAdmin(parkingSpot: ParkingSpot) {
         val parkingSpotMovement = ParkingSpotMovement(
-            parkingSpotId = parkingSpotId,
+            parkingSpotId = parkingSpot.id,
             event = "Check-out realizado pelo administrador: ${parkingSpot.inUseBy}"
         )
         parkingSpotMovementService.create(parkingSpotMovement)
@@ -78,15 +72,13 @@ class CheckInOutService(
 
     fun cleanAllParkingSpots() {
         val listOfParkingSpots = parkingSpotService.findAll()
-        listOfParkingSpots.forEach()
-        {
+        listOfParkingSpots.forEach{
             if (it.inUseBy == null) {
-                throw Exception("Não precisei limpar a vaga  pois não estava em uso")
-                return@forEach
+                println("Não precisei limpar a vaga  pois não estava em uso")
             } else {
-                checkOutFromAdmin(it.id)
+                checkOutFromAdmin(it)
             }
-            throw Exception("Vagas liberadas com sucesso")
         }
+        println("Vagas liberadas com sucesso")
     }
 }

--- a/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/service/CheckInOutService.kt
+++ b/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/service/CheckInOutService.kt
@@ -34,7 +34,8 @@ class CheckInOutService(
 
         val parkingSpotMovement = ParkingSpotMovement(
             parkingSpotId = parkingSpot.id,
-            event = "Check-in realizado pelo veículo: ${vehicle}")
+            event = "Check-in realizado pelo veículo: ${vehicle}"
+        )
         parkingSpotMovementService.create(parkingSpotMovement)
     }
 
@@ -55,5 +56,37 @@ class CheckInOutService(
         parkingSpot.inUseBy = null
         parkingSpotService.update(parkingSpot)
         availableParkingSpotNotificationService.checkOutNotification(parkingSpotId)
+    }
+
+    fun checkOutFromAdmin(parkingSpotId: Int) {
+        val parkingSpot = parkingSpotService.findById(parkingSpotId)
+            ?: throw Exception("Vaga não encontrada")
+
+        if (parkingSpot.inUseBy == null) {
+            throw Exception("Vaga livre")
+        }
+
+        val parkingSpotMovement = ParkingSpotMovement(
+            parkingSpotId = parkingSpotId,
+            event = "Check-out realizado pelo administrador: ${parkingSpot.inUseBy}"
+        )
+        parkingSpotMovementService.create(parkingSpotMovement)
+
+        parkingSpot.inUseBy = null
+        parkingSpotService.update(parkingSpot)
+    }
+
+    fun cleanAllParkingSpots() {
+        val listOfParkingSpots = parkingSpotService.findAll()
+        listOfParkingSpots.forEach()
+        {
+            if (it.inUseBy == null) {
+                throw Exception("Não precisei limpar a vaga  pois não estava em uso")
+                return@forEach
+            } else {
+                checkOutFromAdmin(it.id)
+            }
+            throw Exception("Vagas liberadas com sucesso")
+        }
     }
 }

--- a/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/service/CheckInOutService.kt
+++ b/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/service/CheckInOutService.kt
@@ -75,7 +75,6 @@ class CheckInOutService(
         parkingSpot.inUseBy = null
         parkingSpotService.update(parkingSpot)
     }
-
     fun cleanAllParkingSpots() {
         val listOfParkingSpots = parkingSpotService.findAll()
         listOfParkingSpots.forEach()

--- a/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/service/CheckInOutService.kt
+++ b/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/service/CheckInOutService.kt
@@ -75,6 +75,7 @@ class CheckInOutService(
         parkingSpot.inUseBy = null
         parkingSpotService.update(parkingSpot)
     }
+
     fun cleanAllParkingSpots() {
         val listOfParkingSpots = parkingSpotService.findAll()
         listOfParkingSpots.forEach()

--- a/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/service/ParkingSpotService.kt
+++ b/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/service/ParkingSpotService.kt
@@ -26,7 +26,7 @@ class ParkingSpotService(
     fun findEmptyParkingSpotByFloor(floor: Int): ParkingSpot {
         return parkingSpotRepository.getParkingSpotByFloor(floor).random()
     }
-    
+
     fun update(parkingSpot: ParkingSpot): ParkingSpot {
         return parkingSpotRepository.save(parkingSpot)
     }


### PR DESCRIPTION
## Os administradores da Parky tiveram que remover todos os carros do estacionamento e não querem fazer o check-out um por um dos carros estacionados. Crie um *endpoint* que libere todas as vagas do estacionamento, e gere um movimento de check-out para todas as vagas liberadas.

Obs.: Você deve criar um novo *controller* chamado `AdminController` para colocar esse *endpoint* 😉

Sugestão de endpoint: `POST /admin/free-all-parking-spots`

## Critérios de aceite

- [x]  *Endpoint* criado no novo *controller* `AdminController`.
- [x]  O *endpoint*, além de liberar todas as vagas, gera um movimento de vaga informando que o check-out foi feito por meio do *endpoint* de administradores do sistema.
- [x]  Todas as vagas estão liberadas após a invocação do endpoint.