### PR TITLE
[KT2-33] Adiciona exceptions de CheckIn e CheckOut

### DIFF
--- a/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/controller/CheckInCheckOutController.kt
+++ b/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/controller/CheckInCheckOutController.kt
@@ -27,8 +27,8 @@ class CheckInCheckOutController(
     }
 
     @DeleteMapping("/{parkingSpotId}")
-    fun deleteCheckIn(@PathVariable parkingSpotId: Int): HttpStatus {
-        checkInOutService.removeCheckIn(parkingSpotId)
+    fun checkOut(@PathVariable parkingSpotId: Int): HttpStatus {
+        checkInOutService.checkOut(parkingSpotId)
         return HttpStatus.OK
     }
 }

--- a/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/service/CheckInOutService.kt
+++ b/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/service/CheckInOutService.kt
@@ -4,6 +4,8 @@ import io.devpass.parky.entity.ParkingSpotMovement
 import io.devpass.parky.entity.Vehicle
 import io.devpass.parky.framework.OwnedException
 import io.devpass.parky.requests.CheckInRequest
+import io.devpass.parky.service.exceptions.CheckInException
+import io.devpass.parky.service.exceptions.CheckOutException
 import org.springframework.stereotype.Service
 
 @Service
@@ -15,10 +17,10 @@ class CheckInOutService(
 ) {
     fun createCheckIn(checkInRequest: CheckInRequest) {
         val parkingSpot = parkingSpotService.findById(checkInRequest.parkingSpotId)
-            ?: throw OwnedException("Vaga não encontrada")
+            ?: throw CheckInException("Vaga não encontrada")
 
         if (parkingSpot.inUseBy != null) {
-            throw OwnedException("Vaga ocupada pelo veículo de id: ${parkingSpot.inUseBy}")
+            throw CheckInException("Vaga ocupada pelo veículo de id: ${parkingSpot.inUseBy}")
         }
 
         val vehicle = vehicleService.create(
@@ -38,12 +40,12 @@ class CheckInOutService(
         parkingSpotMovementService.create(parkingSpotMovement)
     }
 
-    fun removeCheckIn(parkingSpotId: Int) {
+    fun checkOut(parkingSpotId: Int) {
         val parkingSpot = parkingSpotService.findById(parkingSpotId)
-            ?: throw Exception("Vaga não encontrada")
+            ?: throw CheckOutException("Vaga não encontrada")
 
         if (parkingSpot.inUseBy == null) {
-            throw Exception("Vaga livre")
+            throw CheckOutException("Vaga livre")
         }
 
         val parkingSpotMovement = ParkingSpotMovement(

--- a/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/service/exceptions/CheckInException.kt
+++ b/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/service/exceptions/CheckInException.kt
@@ -1,0 +1,5 @@
+package io.devpass.parky.service.exceptions
+
+import io.devpass.parky.framework.OwnedException
+
+class CheckInException(message: String) : OwnedException(message)

--- a/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/service/exceptions/CheckOutException.kt
+++ b/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/service/exceptions/CheckOutException.kt
@@ -1,0 +1,5 @@
+package io.devpass.parky.service.exceptions
+
+import io.devpass.parky.framework.OwnedException
+
+class CheckOutException(message: String) : OwnedException(message)


### PR DESCRIPTION
## Os processos de check-in e check-out estão levantando erros genéricos cuja mensagem não aparece para o *client*. Especialize os erros levantados para que as mensagens apareçam para o *client* invocador da API.

Sugestão: Criar package `exceptions` dentro do package `service` para armazenar os arquivos novos.

## Critérios de aceite

- [ ]  Todos os erros levantados programaticamente pelo processo de Check-in e Check-out estão especializados;
- [ ]  As novas `exceptions` herdam `OwnedException`.

Co-authored-by: elaine <elaine.mattos@outlook.pt>