### PR TITLE
[KT2-34] Validação da lista de vagas disponíveis

### DIFF
--- a/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/exceptions/EmptyListException.kt
+++ b/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/exceptions/EmptyListException.kt
@@ -1,0 +1,5 @@
+package io.devpass.parky.exceptions
+
+import io.devpass.parky.framework.OwnedException
+
+class EmptyListException (message: String) : OwnedException(message)

--- a/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/service/ParkingSpotService.kt
+++ b/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/service/ParkingSpotService.kt
@@ -21,20 +21,20 @@ class ParkingSpotService(
     }
 
     fun findEmptyParkingSpotAtRandom(): ParkingSpot {
-        val parkingSpotListIsEmpty = parkingSpotRepository.getRandomEmptyParkingSpot().isEmpty()
-        if (parkingSpotListIsEmpty) {
+        val listOfParkingSpot= parkingSpotRepository.getRandomEmptyParkingSpot()
+        if (listOfParkingSpot.isEmpty()) {
             throw EmptyListException("No parking spot available!")
         } else {
-            return parkingSpotRepository.getRandomEmptyParkingSpot().random()
+            return listOfParkingSpot.random()
         }
     }
 
     fun findEmptyParkingSpotByFloor(floor: Int): ParkingSpot {
-        val parkingSpotByFloorIsEmpty: Boolean = parkingSpotRepository.getParkingSpotByFloor(floor).isEmpty()
-        if (parkingSpotByFloorIsEmpty) {
+        val listOfParkingSpot= parkingSpotRepository.getParkingSpotByFloor(floor)
+        if (listOfParkingSpot.isEmpty()) {
             throw EmptyListException("No parking spot available!")
         } else {
-            return parkingSpotRepository.getParkingSpotByFloor(floor).random()
+            return listOfParkingSpot.random()
         }
     }
 

--- a/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/service/ParkingSpotService.kt
+++ b/solutions/devsprint-luiz-zytkowski-2/src/main/kotlin/io/devpass/parky/service/ParkingSpotService.kt
@@ -1,6 +1,7 @@
 package io.devpass.parky.service
 
 import io.devpass.parky.entity.ParkingSpot
+import io.devpass.parky.exceptions.EmptyListException
 import io.devpass.parky.repository.ParkingSpotRepository
 import org.springframework.stereotype.Service
 
@@ -20,13 +21,23 @@ class ParkingSpotService(
     }
 
     fun findEmptyParkingSpotAtRandom(): ParkingSpot {
-        return parkingSpotRepository.getRandomEmptyParkingSpot().random()
+        val parkingSpotListIsEmpty = parkingSpotRepository.getRandomEmptyParkingSpot().isEmpty()
+        if (parkingSpotListIsEmpty) {
+            throw EmptyListException("No parking spot available!")
+        } else {
+            return parkingSpotRepository.getRandomEmptyParkingSpot().random()
+        }
     }
 
     fun findEmptyParkingSpotByFloor(floor: Int): ParkingSpot {
-        return parkingSpotRepository.getParkingSpotByFloor(floor).random()
+        val parkingSpotByFloorIsEmpty: Boolean = parkingSpotRepository.getParkingSpotByFloor(floor).isEmpty()
+        if (parkingSpotByFloorIsEmpty) {
+            throw EmptyListException("No parking spot available!")
+        } else {
+            return parkingSpotRepository.getParkingSpotByFloor(floor).random()
+        }
     }
-    
+
     fun update(parkingSpot: ParkingSpot): ParkingSpot {
         return parkingSpotRepository.save(parkingSpot)
     }


### PR DESCRIPTION
[KT2-34] Validar se a lista de vagas disponíveis para o processo aleatório contem elementos antes de utilizar o “.random()”

## Os processos de geração de vagas aleatórias estão suscetíveis à um erro chamado `NoSuchElementException`, isso ocorre quando o resultado do repository de vagas é uma lista vazia. Adicione uma validação nos dois processos de vaga aleatória para levantar exceções customizadas avisando o usuário de que não existem vagas disponíveis para uso.

## Critérios de aceite

- [x]  Validações feitas a nível de *service*
- [x]  Exceções levantadas herdam `OwnedException`
- [x]  Validação programada no processo de vaga aleatória
- [x]  Validação programada no processo de vaga aleatória por andar