### PR TITLE
[KT2-26] Criar evento Checkin duplicado

### DIFF
--- a/solutions/devsprint-michel-ferreira-2/src/main/kotlin/io/devpass/parky/entity/ParkingSpotEvent.kt
+++ b/solutions/devsprint-michel-ferreira-2/src/main/kotlin/io/devpass/parky/entity/ParkingSpotEvent.kt
@@ -1,5 +1,6 @@
 package io.devpass.parky.entity
 
+import io.devpass.parky.enums.EnumCheckInOut
 import org.hibernate.annotations.CreationTimestamp
 import java.time.LocalDateTime
 import javax.persistence.*
@@ -15,7 +16,7 @@ data class ParkingSpotEvent(
     var parkingSpotId: Int,
 
     @Column(name = "event", nullable = false)
-    var event: String,
+    var event: EnumCheckInOut,
 
     @Column(name = "vehicle_id", nullable = false)
     var vehicleId : String,

--- a/solutions/devsprint-michel-ferreira-2/src/main/kotlin/io/devpass/parky/enums/EnumCheckInOut.kt
+++ b/solutions/devsprint-michel-ferreira-2/src/main/kotlin/io/devpass/parky/enums/EnumCheckInOut.kt
@@ -1,0 +1,5 @@
+package io.devpass.parky.enums
+
+enum class EnumCheckInOut {
+    CHECKIN, CHECKOUT, CHECKIN_DUPLICADO
+}

--- a/solutions/devsprint-michel-ferreira-2/src/main/kotlin/io/devpass/parky/repository/ParkingSpotRepository.kt
+++ b/solutions/devsprint-michel-ferreira-2/src/main/kotlin/io/devpass/parky/repository/ParkingSpotRepository.kt
@@ -8,4 +8,12 @@ import org.springframework.stereotype.Repository
 interface ParkingSpotRepository : CrudRepository<ParkingSpot, Int> {
     fun findByFloorAndSpot(floor: Int, spot: Int): ParkingSpot?
     fun findByInUseBy(inUseBy: String): ParkingSpot?
+
+    //TODO validar se faz sentido usar, nao tinha visto que ja tinha uma validacao de duplicidade... CheckInOutService ln:33
+    override fun <S : ParkingSpot> save(parkingSpot: S): S {
+        if(parkingSpot.inUseBy?.let { findByInUseBy(it) } != null){
+            return parkingSpot
+        }
+        return save(parkingSpot)
+    }
 }

--- a/solutions/devsprint-michel-ferreira-2/src/main/kotlin/io/devpass/parky/service/CheckInOutService.kt
+++ b/solutions/devsprint-michel-ferreira-2/src/main/kotlin/io/devpass/parky/service/CheckInOutService.kt
@@ -3,13 +3,14 @@ package io.devpass.parky.service
 import io.devpass.parky.entity.ParkingSpot
 import io.devpass.parky.entity.ParkingSpotEvent
 import io.devpass.parky.entity.Vehicle
+import io.devpass.parky.enums.EnumCheckInOut
 import io.devpass.parky.framework.CheckInException
 import io.devpass.parky.framework.CheckOutException
 import io.devpass.parky.repository.ParkingSpotEventRepository
 import io.devpass.parky.repository.ParkingSpotRepository
 import io.devpass.parky.requests.CheckInRequest
 import io.devpass.parky.requests.CheckOutRequest
-import io.devpass.parky.service.Utils.ValidatedCheckOut
+import io.devpass.parky.service.tools.ValidatedCheckOut
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
 
@@ -19,7 +20,7 @@ class CheckInOutService(
     private val parkingSpotEventRepository: ParkingSpotEventRepository,
     private val parkingSpotRepository: ParkingSpotRepository
 ) {
-    fun checkIn(checkInRequest: CheckInRequest): String {
+    fun checkIn(checkInRequest: CheckInRequest) {
         val vehicle = vehicleService.createIfNotExists(
             (Vehicle(
                 licensePlate = checkInRequest.vehicleCheckIn.licensePlate,
@@ -30,7 +31,16 @@ class CheckInOutService(
         )
 
         parkingSpotRepository.findByInUseBy(vehicle.id)
-            ?.let { throw CheckInException("Car already parked in spot: ${it.spot} and floor: ${it.floor}") }
+            ?.let {
+                parkingSpotEventRepository.save(
+                    ParkingSpotEvent(
+                        parkingSpotId = it.id,
+                        event = EnumCheckInOut.CHECKIN_DUPLICADO,
+                        vehicleId = it.inUseBy!!
+                    )
+                )
+                throw CheckInException("Car already parked in spot: ${it.spot} and floor: ${it.floor}")
+            }
 
         val freeSpot = parkingSpotRepository.findByFloorAndSpot(
             floor = checkInRequest.spotCheckIn.floor,
@@ -47,16 +57,15 @@ class CheckInOutService(
         parkingSpotEventRepository.save(
             ParkingSpotEvent(
                 parkingSpotId = freeSpot.id,
-                event = "Check-in",
+                event = EnumCheckInOut.CHECKIN,
                 vehicleId = vehicle.id
             )
         )
-        return vehicle.id
     }
 
-    fun checkOut(checkOutRequest: CheckOutRequest)  {
+    fun checkOut(checkOutRequest: CheckOutRequest) {
         val vehicle = vehicleService.findVehicleLicensePlate(checkOutRequest.vehicleCheckOut.licensePlate)
-            ?: throw CheckOutException("Vehicle not Found, please Check-in first!")
+            ?: throw CheckOutException("Vehicle with this license plate not Found, please Check-in first!")
 
         val parkingSpotCheckOut = parkingSpotRepository.findByFloorAndSpot(
             checkOutRequest.spotCheckOut.floor,
@@ -66,18 +75,18 @@ class CheckInOutService(
         val validatedCheckOutRequest: ValidatedCheckOut = with(checkOutRequest) {
             validateParkingSpot(parkingSpotCheckOut)
 
-            // validar possibilidade de remover o !!
-            validateParkingSpotIsEmpty(parkingSpotCheckOut!!.inUseBy)
+            val inUseBy: String = parkingSpotCheckOut!!.inUseBy
+                ?: throw CheckOutException("There are no vehicles at this spot")
 
-            // nome do metodo nao condiz com o retorno
-           val inUseBy = (vehicleBelongsToTheSpot(vehicle.id, parkingSpotCheckOut.inUseBy))
+            vehicleBelongsToTheSpot(vehicle.id, parkingSpotCheckOut.inUseBy)
 
             return@with ValidatedCheckOut(
-                id = vehicle.id,
+                vehicleId = vehicle.id,
                 inUseBy = inUseBy,
                 parkingSpotId = parkingSpotCheckOut.id,
                 floor = parkingSpotCheckOut.floor,
-                spot = parkingSpotCheckOut.spot
+                spot = parkingSpotCheckOut.spot,
+                event = EnumCheckInOut.CHECKOUT
             )
         }
 
@@ -87,10 +96,10 @@ class CheckInOutService(
         }
 
         val parkingSpotEventCheckout = ParkingSpotEvent(
+            vehicleId = validatedCheckOutRequest.vehicleId,
             parkingSpotId = validatedCheckOutRequest.parkingSpotId,
-            event = "Check-out",
+            event = EnumCheckInOut.CHECKOUT,
             createdAt = LocalDateTime.now(),
-            vehicleId = vehicle.id
         )
 
         parkingSpotEventRepository.save(parkingSpotEventCheckout)
@@ -99,17 +108,11 @@ class CheckInOutService(
     fun validateParkingSpot(parkingSpot: ParkingSpot?): ParkingSpot =
         parkingSpot ?: throw CheckOutException("Invalid parking spot OR doesn't exist!")
 
-    fun validateParkingSpotIsEmpty(inUseBy: String?): String? =
-        inUseBy ?: throw CheckOutException("There are no vehicles at this spot")
-
-    fun vehicleBelongsToTheSpot(vehicleId: String, inUseBy: String?): String {
+    fun vehicleBelongsToTheSpot(vehicleId: String, inUseBy: String?): Boolean {
         if (vehicleId == inUseBy) {
-            return inUseBy
+            return true
         } else {
             throw CheckOutException("Invalid Spot! Please Insert correct spot corresponding to the vehicle location")
         }
     }
-
-    fun validateIfCarIsAlreadyParked(inUseBy: String?, vehicleId: String?): Boolean = (inUseBy == vehicleId)
-
 }

--- a/solutions/devsprint-michel-ferreira-2/src/main/kotlin/io/devpass/parky/service/Utils/ValidatedCheckOut.kt
+++ b/solutions/devsprint-michel-ferreira-2/src/main/kotlin/io/devpass/parky/service/Utils/ValidatedCheckOut.kt
@@ -1,9 +1,0 @@
-package io.devpass.parky.service.Utils
-
-data class ValidatedCheckOut(
-    val id : String,
-    val parkingSpotId : Int,
-    val inUseBy : String,
-    val floor : Int,
-    val spot : Int
-)

--- a/solutions/devsprint-michel-ferreira-2/src/main/kotlin/io/devpass/parky/service/tools/ValidatedCheckOut.kt
+++ b/solutions/devsprint-michel-ferreira-2/src/main/kotlin/io/devpass/parky/service/tools/ValidatedCheckOut.kt
@@ -1,0 +1,12 @@
+package io.devpass.parky.service.tools
+
+import io.devpass.parky.enums.EnumCheckInOut
+
+data class ValidatedCheckOut(
+    val vehicleId : String,
+    val parkingSpotId : Int,
+    val inUseBy : String,
+    val floor : Int,
+    val spot : Int,
+    val event: EnumCheckInOut
+)


### PR DESCRIPTION
add EnumCheckInOut
add save to ParkingSpot, validates if inUseBy doesn't exist then save.
update ParkingSpotEvent.event to receive new type EnumCheckInOut
fix methods

## O que é

Complementar o service de check(in/out) para conter a validação caso ocorra o cenário de check-in para um veículo já estacionado na vaga.

Criar um novo evento no histórico “CHECKIN_DUPLICADO” para contemplar esse cenário.

Criar camada de validação para tratar checkin e checkout

Referência: [https://docs.spring.io/spring-data/jpa/docs/current/reference/html/#jpa.query-methods.query-creation](https://docs.spring.io/spring-data/jpa/docs/current/reference/html/#jpa.query-methods.query-creation)

## Critérios de aceitação

- [ ]  Método valida se a vaga estava sendo utilizada pelo mesmo veiculo
- [ ]  Método insere um movimento de vaga informando check-out duplicado